### PR TITLE
Request location update for homeassistant.update_entity service call

### DIFF
--- a/custom_components/life360/const.py
+++ b/custom_components/life360/const.py
@@ -13,15 +13,18 @@ COMM_MAX_RETRIES = 3
 COMM_TIMEOUT = ClientTimeout(sock_connect=15, total=60)
 SPEED_FACTOR_MPH = 2.25
 SPEED_DIGITS = 1
-UPDATE_INTERVAL = timedelta(seconds=10)
+UPDATE_INTERVAL_SEC = 10
+UPDATE_INTERVAL = timedelta(seconds=UPDATE_INTERVAL_SEC)
 
 ATTR_ADDRESS = "address"
 ATTR_AT_LOC_SINCE = "at_loc_since"
+ATTR_CIRCLES = "circles"
 ATTR_DRIVING = "driving"
 ATTR_LAST_SEEN = "last_seen"
 ATTR_PLACE = "place"
 ATTR_REASON = "reason"
 ATTR_SPEED = "speed"
+ATTR_STATUS = "status"
 ATTR_WIFI_ON = "wifi_on"
 ATTR_IGNORED_UPDATE_REASONS = "ignored_update_reasons"
 

--- a/custom_components/life360/coordinator.py
+++ b/custom_components/life360/coordinator.py
@@ -481,8 +481,8 @@ class Life360CentralDataUpdateCoordinator(DataUpdateCoordinator[None]):
                 f"location update request for {member_name} "
                 f"via {circle_stats[circle_id].name}"
             )
+            self.logger.debug("Sending %s", msg)
             try:
-                self.logger.debug("Sending %s", msg)
                 result = await api.update_location(circle_id, member_id)
             except Life360Error as exc:
                 self.logger.error(


### PR DESCRIPTION
The homeassistant.update_entity service call would only cause the life360 integration to immediately query the server for new data it currently has. Basically, jump to the end of the current 10 second query period, and get any new data the server might have from member devices since the last query.

Note, though, that it is possible some member devices haven't provided new location data to the server for an extended period of time (e.g., when the devices aren't moving.) So, the effect of the homeassistant.update_entity service call is minimal (i.e., only getting any new data the member devices might have decided on their own to send to the Life360 server since the last time the life360 integration queried the server.)

This change sends a request to the server to have the member device update its location first before the life360 integration fetches data from the server. This can be used to get the most up-to-date location data from a member's device. E.g., when some other entity (such as a router-based tracker for the same device) indicates the device has come home, this can attempt to update the life360 tracker entity so it agrees as quickly as possible.

However, just because the device has been requested to update its location, it's still possible it won't (e.g., it has a bad network connection, has been turned off, etc.)