### PR TITLE
Use UTC datetimes internally & fix new HA 2024.11 error

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -54,10 +54,14 @@ jobs:
         # 0.13.129 -> HA 2024.6.0b5
         # 0.13.136 -> HA 2024.6.4
         # 0.13.148 -> HA 2024.7.4
+        # 0.13.175 -> HA 2024.10.4
+        # 0.13.181 -> HA 2024.11.0
         include:
           - hass-test-cc-version: "0.13.136"
             python-version: "3.12"
-          - hass-test-cc-version: "0.13.148"
+          - hass-test-cc-version: "0.13.175"
+            python-version: "3.12"
+          - hass-test-cc-version: "0.13.181"
             python-version: "3.12"
     steps:
       - name: 📥 Checkout the repository

--- a/custom_components/life360/__init__.py
+++ b/custom_components/life360/__init__.py
@@ -99,7 +99,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             mem_crd = MemberDataUpdateCoordinator(hass, coordinator, mid)
             config_entries.current_entry.set(entry_was)
             mem_coordinator[mid] = mem_crd
-            coros.append(mem_crd.async_config_entry_first_refresh())
+            coros.append(mem_crd.async_refresh())
         if coros:
             await asyncio.gather(*coros)
             if forward:

--- a/custom_components/life360/coordinator.py
+++ b/custom_components/life360/coordinator.py
@@ -225,7 +225,7 @@ class CirclesMembersDataUpdateCoordinator(DataUpdateCoordinator[CirclesMembersDa
 
     async def _update_data(self, retry: bool) -> tuple[CirclesMembersData, bool]:
         """Update Life360 Circles & Members seen from all enabled accounts."""
-        start = dt_util.now()
+        start = dt_util.utcnow()
         _LOGGER.debug("Begin updating Circles & Members")
         cancelled = False
         try:
@@ -237,7 +237,7 @@ class CirclesMembersDataUpdateCoordinator(DataUpdateCoordinator[CirclesMembersDa
             _LOGGER.debug(
                 "Updating Circles & Members %stook %s",
                 "(which was cancelled) " if cancelled else "",
-                dt_util.now() - start,
+                dt_util.utcnow() - start,
             )
 
     async def _do_update(self, retry: bool) -> tuple[CirclesMembersData, bool]:
@@ -421,7 +421,7 @@ class CirclesMembersDataUpdateCoordinator(DataUpdateCoordinator[CirclesMembersDa
         if self._acct_data[aid].failed.is_set():
             return RequestError.NO_DATA
 
-        start = dt_util.now()
+        start = dt_util.utcnow()
         login_error_retries = 0
         delay: int | None = None
         delay_reason = ""
@@ -434,7 +434,7 @@ class CirclesMembersDataUpdateCoordinator(DataUpdateCoordinator[CirclesMembersDa
                 if delay is not None:
                     if (
                         not warned
-                        and (dt_util.now() - start).total_seconds() + delay > 60 * 60
+                        and (dt_util.utcnow() - start).total_seconds() + delay > 60 * 60
                     ):
                         _LOGGER.warning(
                             "Getting response from Life360 for %s "

--- a/custom_components/life360/device_tracker.py
+++ b/custom_components/life360/device_tracker.py
@@ -25,6 +25,7 @@ from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.restore_state import RestoreEntity
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
+from homeassistant.util import dt as dt_util
 from homeassistant.util.unit_conversion import SpeedConverter
 from homeassistant.util.unit_system import METRIC_SYSTEM
 
@@ -272,10 +273,12 @@ class Life360DeviceTracker(
 
             attrs: dict[str, Any] = {
                 ATTR_ADDRESS: address,
-                ATTR_AT_LOC_SINCE: self._data.loc.details.at_loc_since,
+                ATTR_AT_LOC_SINCE: dt_util.as_local(
+                    self._data.loc.details.at_loc_since
+                ),
                 ATTR_BATTERY_CHARGING: self._data.loc.battery_charging,
                 ATTR_DRIVING: self.driving,
-                ATTR_LAST_SEEN: self._data.loc.details.last_seen,
+                ATTR_LAST_SEEN: dt_util.as_local(self._data.loc.details.last_seen),
                 ATTR_PLACE: self._data.loc.details.place,
                 ATTR_SPEED: speed,
                 ATTR_WIFI_ON: self._data.loc.wifi_on,
@@ -374,8 +377,8 @@ class Life360DeviceTracker(
                     "%s: Ignoring location update because "
                     "last_seen (%s) < previous last_seen (%s)",
                     self,
-                    last_seen,
-                    prev_seen,
+                    dt_util.as_local(last_seen),
+                    dt_util.as_local(prev_seen),
                 )
             if bad_accuracy and ATTR_GPS_ACCURACY not in self._ignored_update_reasons:
                 self._ignored_update_reasons.append(ATTR_GPS_ACCURACY)

--- a/custom_components/life360/helpers.py
+++ b/custom_components/life360/helpers.py
@@ -133,19 +133,19 @@ class LocationDetails:
 
     @staticmethod
     def to_datetime(value: Any) -> datetime:
-        """Extract value at key and convert to datetime.
+        """Extract value at key and convert to datetime in UTC.
 
         Raises ValueError if value is not a valid datetime or representation of one.
         """
         if isinstance(value, datetime):
-            return dt_util.as_local(value)
+            return dt_util.as_utc(value)
         try:
             parsed_value = dt_util.parse_datetime(value)
         except TypeError:
             raise ValueError from None
         if parsed_value is None:
             raise ValueError
-        return dt_util.as_local(parsed_value)
+        return dt_util.as_utc(parsed_value)
 
     @classmethod
     def from_dict(cls, restored: Mapping[str, Any]) -> Self:
@@ -178,7 +178,7 @@ class LocationDetails:
 
         return cls(
             address,
-            dt_util.as_local(dt_util.utc_from_timestamp(int(raw_loc["since"]))),
+            dt_util.utc_from_timestamp(int(raw_loc["since"])),
             bool(int(raw_loc["isDriving"])),
             # Life360 reports accuracy in feet, but Device Tracker expects
             # gps_accuracy in meters.
@@ -187,7 +187,7 @@ class LocationDetails:
                     float(raw_loc["accuracy"]), UnitOfLength.FEET, UnitOfLength.METERS
                 )
             ),
-            dt_util.as_local(dt_util.utc_from_timestamp(int(raw_loc["timestamp"]))),
+            dt_util.utc_from_timestamp(int(raw_loc["timestamp"])),
             float(raw_loc["latitude"]),
             float(raw_loc["longitude"]),
             raw_loc["name"] or None,

--- a/custom_components/life360/manifest.json
+++ b/custom_components/life360/manifest.json
@@ -3,11 +3,11 @@
   "name": "Life360",
   "codeowners": ["@pnbruckner"],
   "config_flow": true,
-  "documentation": "https://github.com/pnbruckner/ha-life360/blob/0.5.3/README.md",
+  "documentation": "https://github.com/pnbruckner/ha-life360/blob/0.5.4b0/README.md",
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/pnbruckner/ha-life360/issues",
   "loggers": ["life360"],
   "requirements": ["life360==7.0.1"],
   "single_config_entry": true,
-  "version": "0.5.3"
+  "version": "0.5.4b0"
 }

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,4 +1,4 @@
 -r requirements.txt
 
-# HA 2024.10.4
-pytest-homeassistant-custom-component==0.13.175
+# HA 2024.11.0
+pytest-homeassistant-custom-component==0.13.181

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,4 +1,4 @@
 -r requirements.txt
 
-# HA 2024.7.4
-pytest-homeassistant-custom-component==0.13.148
+# HA 2024.10.4
+pytest-homeassistant-custom-component==0.13.175


### PR DESCRIPTION
Python datetime object comparisons and math don't work as expected when the objects are aware and have the same tzinfo attribute. Basically, the fold attribute is ignored in this case, which can lead to wrong results.

Avoid this problem by using aware times in UTC internally. Only use local time zone for user visible attributes.

Also, HA 2024.11 no longer allows calling async_config_entry_first_refresh after the config entry has been set up. Since we have two subclasses of DataUpdateCoordinator that share the same config entry, call async_refresh instead for the MemberDataUpdateCoordinator.

Fixes #36 