### PR TITLE
Support Home Assistant 2024.8.3 or newer

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -60,13 +60,22 @@ jobs:
         # 0.13.205 -> HA 2025.1.4
         # --- 3.13
         # 0.13.215 -> HA 2025.2.5
-        # 0.13.224 -> HA 2025.3.3
+        # 0.13.225 -> HA 2025.3.4
+        # 0.13.236 -> HA 2025.4.4
+        # 0.13.246 -> HA 2025.5.3
+        # 0.13.254 -> HA 2025.6.3
+        # 0.13.264 -> HA 2025.7.4
+        # 0.13.272 -> HA 2025.8.3
+        # 0.13.278 -> HA 2025.9.1
         include:
+          # Oldest HA for Python 3.13
           - hass-test-cc-version: "0.13.195"
             python-version: "3.13"
+          # Newest HA for Python 3.12
           - hass-test-cc-version: "0.13.205"
             python-version: "3.12"
-          - hass-test-cc-version: "0.13.224"
+          # Newest HA
+          - hass-test-cc-version: "0.13.278"
             python-version: "3.13"
     steps:
       - name: 📥 Checkout the repository

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -63,18 +63,14 @@ jobs:
         # 0.13.225 -> HA 2025.3.4
         # 0.13.236 -> HA 2025.4.4
         # 0.13.246 -> HA 2025.5.3
+        # 0.13.252 -> HA 2025.6.1 # Fixed error from pycares about "Thread-1 (_run_safe_shutdown_loop)"
         # 0.13.254 -> HA 2025.6.3
         # 0.13.264 -> HA 2025.7.4
         # 0.13.272 -> HA 2025.8.3
         # 0.13.278 -> HA 2025.9.1
         include:
-          # Oldest HA for Python 3.13
-          - hass-test-cc-version: "0.13.195"
+          - hass-test-cc-version: "0.13.252"
             python-version: "3.13"
-          # Newest HA for Python 3.12
-          - hass-test-cc-version: "0.13.205"
-            python-version: "3.12"
-          # Newest HA
           - hass-test-cc-version: "0.13.278"
             python-version: "3.13"
     steps:

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -62,8 +62,6 @@ jobs:
         # 0.13.215 -> HA 2025.2.5
         # 0.13.224 -> HA 2025.3.3
         include:
-          - hass-test-cc-version: "0.13.155"
-            python-version: "3.12"
           - hass-test-cc-version: "0.13.195"
             python-version: "3.13"
           - hass-test-cc-version: "0.13.205"

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -39,30 +39,37 @@ jobs:
         #   See core/.github/workflows/ci.yaml:
         #   ALL_PYTHON_VERSIONS & DEFAULT_PYTHON*
         # ---------------------------------------
-        # HA 2023.3 -> 3.10*, 3.11
-        # HA 2023.8 -> 3.11
-        # HA 2023.11 -> 3.11*, 3.12
-        # HA 2024.4 -> 3.12
+        # HA 2024.4  -> 3.12
+        # HA 2024.12 -> 3.12*, 3.13
+        # HA 2025.2  -> 3.13
 
         # hass-test-cc versions
         # ---------------------
-        # 0.13.42 -> HA 2023.7.0
-        # 0.13.49 -> HA 2023.8.0
-        # 0.13.109 -> HA 2024.3.3
-        # 0.13.115 -> HA 2024.4.4
+        # --- 3.12
         # 0.13.128 -> HA 2024.6.0b4 # Removed mypy-dev
         # 0.13.129 -> HA 2024.6.0b5
         # 0.13.136 -> HA 2024.6.4
         # 0.13.148 -> HA 2024.7.4
+        # 0.13.155 -> HA 2024.8.3
+        # 0.13.164 -> HA 2024.9.3
         # 0.13.175 -> HA 2024.10.4
         # 0.13.181 -> HA 2024.11.0
+        # 0.13.184 -> HA 2024.11.3
+        # --- 3.12, 3.13
+        # 0.13.195 -> HA 2024.12.5
+        # 0.13.205 -> HA 2025.1.4
+        # --- 3.13
+        # 0.13.215 -> HA 2025.2.5
+        # 0.13.224 -> HA 2025.3.3
         include:
-          - hass-test-cc-version: "0.13.136"
+          - hass-test-cc-version: "0.13.155"
             python-version: "3.12"
-          - hass-test-cc-version: "0.13.175"
+          - hass-test-cc-version: "0.13.195"
+            python-version: "3.13"
+          - hass-test-cc-version: "0.13.205"
             python-version: "3.12"
-          - hass-test-cc-version: "0.13.181"
-            python-version: "3.12"
+          - hass-test-cc-version: "0.13.224"
+            python-version: "3.13"
     steps:
       - name: 📥 Checkout the repository
         uses: actions/checkout@v4

--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ You can put whatever you want in the "Account identifier" box.
 
 ## Versions
 
-Home Assistant 2023.8 or newer is currently supported.
+This custom integration supports HomeAssistant versions 2024.8.3 or newer.
 
 ## Services
 

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ Alternatively, go to Settings -> Devices & services and click the **`+ ADD INTEG
 Find or search for "Life360", click on it, then follow the prompts.
 
 ### Configuration Options
-#### Max GPS Accuracy
+#### GPS Accuracy Radius Limit
 
 Each location update has a GPS accuracy value (see the entity's corresponding attribute.)
 You can think of each update as a circle whose center is defined by latitude & longitude,
@@ -113,6 +113,9 @@ therefore the _less_ accurate the location fix.
 
 This configuration option can be used to reject location updates that are _less_ accurate
 (i.e., have _larger_ accuracy values) than the entered value (in meters.)
+Or it can be left blank, in which case updates will not be rejected due to their accuracy.
+If used, a value of 100m is recommended as a reasonable starting point.
+Adjust up or down depending on your desire for more updates, or fewer but more accurate updates.
 
 #### Driving Speed Threshold
 

--- a/custom_components/life360/__init__.py
+++ b/custom_components/life360/__init__.py
@@ -17,7 +17,7 @@ except ImportError as err:
 import voluptuous as vol
 
 from homeassistant import config_entries
-from homeassistant.const import CONF_ENTITY_ID, Platform
+from homeassistant.const import CONF_ENTITY_ID, ENTITY_MATCH_ALL, Platform
 from homeassistant.core import HomeAssistant, ServiceCall, callback
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.dispatcher import async_dispatcher_send
@@ -44,7 +44,11 @@ _LOGGER = logging.getLogger(__name__)
 _PLATFORMS = [Platform.BINARY_SENSOR, Platform.DEVICE_TRACKER]
 
 _UPDATE_LOCATION_SCHEMA = vol.Schema(
-    {vol.Required(CONF_ENTITY_ID): vol.Any(vol.All(vol.Lower, "all"), cv.entity_ids)}
+    {
+        vol.Required(CONF_ENTITY_ID): vol.Any(
+            vol.All(vol.Lower, ENTITY_MATCH_ALL), cv.entity_ids
+        )
+    }
 )
 
 

--- a/custom_components/life360/__init__.py
+++ b/custom_components/life360/__init__.py
@@ -147,7 +147,7 @@ async def async_unload_entry(hass: HomeAssistant, entry: L360ConfigEntry) -> boo
         *(
             mem_crd.async_shutdown()
             for mem_crd in entry.runtime_data.mem_coordinator.values()
-        )
+        ),
     )
     # Unload components for our platforms.
     return await hass.config_entries.async_unload_platforms(entry, _PLATFORMS)

--- a/custom_components/life360/__init__.py
+++ b/custom_components/life360/__init__.py
@@ -136,6 +136,19 @@ async def async_setup_entry(hass: HomeAssistant, entry: L360ConfigEntry) -> bool
 
 async def async_unload_entry(hass: HomeAssistant, entry: L360ConfigEntry) -> bool:
     """Unload config entry."""
+    # The coordinators will eventually be shut down when their listeners stop listening
+    # or ultimately when the config entry's "on unload" list is processed (which happens
+    # after this method returns.) And any background tasks created by the coordinators
+    # will be canceled after the "on unload" processing. But by then, resources those
+    # tasks were using may have disappeared. So, shut down the coordinators now to give
+    # them a chance to shutdown the background tasks themselves.
+    await asyncio.gather(
+        entry.runtime_data.coordinator.async_shutdown(),
+        *(
+            mem_crd.async_shutdown()
+            for mem_crd in entry.runtime_data.mem_coordinator.values()
+        )
+    )
     # Unload components for our platforms.
     return await hass.config_entries.async_unload_platforms(entry, _PLATFORMS)
 

--- a/custom_components/life360/binary_sensor.py
+++ b/custom_components/life360/binary_sensor.py
@@ -11,13 +11,12 @@ from homeassistant.components.binary_sensor import (
     BinarySensorDeviceClass,
     BinarySensorEntity,
 )
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from .const import ATTRIBUTION, DOMAIN, SIGNAL_ACCT_STATUS
-from .coordinator import CirclesMembersDataUpdateCoordinator
+from .const import ATTRIBUTION, SIGNAL_ACCT_STATUS
+from .coordinator import CirclesMembersDataUpdateCoordinator, L360ConfigEntry
 from .helpers import AccountID, ConfigOptions
 
 _LOGGER = logging.getLogger(__name__)
@@ -25,16 +24,14 @@ _LOGGER = logging.getLogger(__name__)
 
 async def async_setup_entry(
     hass: HomeAssistant,
-    entry: ConfigEntry,
+    entry: L360ConfigEntry,
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up the binary sensory platform."""
-    coordinator = cast(
-        CirclesMembersDataUpdateCoordinator, hass.data[DOMAIN]["coordinator"]
-    )
+    coordinator = entry.runtime_data.coordinator
     entities: dict[AccountID, Life360BinarySensor] = {}
 
-    async def process_config(hass: HomeAssistant, entry: ConfigEntry) -> None:
+    async def process_config(hass: HomeAssistant, entry: L360ConfigEntry) -> None:
         """Add and/or remove binary online sensors."""
         options = ConfigOptions.from_dict(entry.options)
         aids = set(options.accounts)
@@ -111,7 +108,7 @@ class Life360BinarySensor(BinarySensorEntity):
         )
 
     async def _async_config_entry_updated(
-        self, _: HomeAssistant, entry: ConfigEntry
+        self, _: HomeAssistant, entry: L360ConfigEntry
     ) -> None:
         """Run when the config entry has been updated."""
         enabled = ConfigOptions.from_dict(entry.options).accounts[self.aid].enabled

--- a/custom_components/life360/binary_sensor.py
+++ b/custom_components/life360/binary_sensor.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import asyncio
-from functools import cached_property, partial
+from functools import cached_property, partial  # pylint: disable=hass-deprecated-import
 import logging
 from typing import cast
 

--- a/custom_components/life360/config_flow.py
+++ b/custom_components/life360/config_flow.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from functools import cached_property
+from functools import cached_property  # pylint: disable=hass-deprecated-import
 import logging
 from typing import Any, cast
 

--- a/custom_components/life360/config_flow.py
+++ b/custom_components/life360/config_flow.py
@@ -466,10 +466,6 @@ class Life360ConfigFlow(ConfigFlow, Life360Flow, domain=DOMAIN):
         self, _: dict[str, Any] | None = None
     ) -> FlowResult:
         """Handle a config flow initiated by the user."""
-        # manifest.json single_config_entry option added in 2024.3. Once versions before
-        # that are no longer supported, this check can be removed.
-        if self._async_current_entries():
-            return self.async_abort(reason="single_instance_allowed")
         return await self.async_step_init()
 
     async def async_step_done(self, _: dict[str, Any] | None = None) -> FlowResult:

--- a/custom_components/life360/coordinator.py
+++ b/custom_components/life360/coordinator.py
@@ -759,3 +759,14 @@ class MemberDataUpdateCoordinator(DataUpdateCoordinator[MemberData]):
                 data.loc.details.place = place
 
         return data
+
+
+@dataclass
+class L360Coordinators:
+    """Life360 data update coordinators."""
+
+    coordinator: CirclesMembersDataUpdateCoordinator
+    mem_coordinator: dict[MemberID, MemberDataUpdateCoordinator]
+
+
+type L360ConfigEntry = ConfigEntry[L360Coordinators]

--- a/custom_components/life360/coordinator.py
+++ b/custom_components/life360/coordinator.py
@@ -104,6 +104,13 @@ class CirclesMembersDataUpdateCoordinator(DataUpdateCoordinator[CirclesMembersDa
             self.config_entry.add_update_listener(self._config_entry_updated)
         )
 
+    async def async_shutdown(self) -> None:
+        """Cancel any scheduled call, and ignore new runs."""
+        await super().async_shutdown()
+        # Now that no new tasks should be created, stop any ongoing ones.
+        await self._stop_tasks()
+        self._delete_acct_data(list(self._acct_data))
+
     def acct_online(self, aid: AccountID) -> bool:
         """Return if account is online."""
         # When config updates and there's a new, enabled account, binary sensor could
@@ -614,20 +621,7 @@ class CirclesMembersDataUpdateCoordinator(DataUpdateCoordinator[CirclesMembersDa
         if old_accts == new_accts:
             return
 
-        # Prevent any client requests from starting.
-        self._client_request_ok.clear()
-
-        # Stop everything.
-        tasks = set(self._client_tasks)
-        if self._fg_update_task:
-            tasks.add(self._fg_update_task)
-        if self._bg_update_task:
-            tasks.add(self._bg_update_task)
-        for task in tasks:
-            task.cancel()
-        await asyncio.gather(*tasks, return_exceptions=True)
-        self._fg_update_task = None
-        self._bg_update_task = None
+        await self._stop_tasks()
 
         del_acct_ids = old_acct_ids - new_acct_ids
         self._delete_acct_data(del_acct_ids)
@@ -651,6 +645,23 @@ class CirclesMembersDataUpdateCoordinator(DataUpdateCoordinator[CirclesMembersDa
 
         # Allow client requests to proceed.
         self._client_request_ok.set()
+
+    async def _stop_tasks(self) -> None:
+        """Stop all background tasks."""
+        # Prevent any client requests from starting.
+        self._client_request_ok.clear()
+
+        # Stop everything.
+        tasks = set(self._client_tasks)
+        if self._fg_update_task:
+            tasks.add(self._fg_update_task)
+            self._fg_update_task = None
+        if self._bg_update_task:
+            tasks.add(self._bg_update_task)
+            self._bg_update_task = None
+        for task in tasks:
+            task.cancel()
+        await asyncio.gather(*tasks, return_exceptions=True)
 
     def _create_acct_data(self, aids: Iterable[AccountID]) -> None:
         """Create data needed for each specified Life360 account."""

--- a/custom_components/life360/device_tracker.py
+++ b/custom_components/life360/device_tracker.py
@@ -12,7 +12,6 @@ from typing import Any, cast
 
 from homeassistant.components.device_tracker import SourceType
 from homeassistant.components.device_tracker.config_entry import TrackerEntity
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
     ATTR_BATTERY_CHARGING,
     ATTR_GPS_ACCURACY,
@@ -40,15 +39,11 @@ from .const import (
     ATTR_SPEED,
     ATTR_WIFI_ON,
     ATTRIBUTION,
-    DOMAIN,
     SIGNAL_MEMBERS_CHANGED,
     SIGNAL_UPDATE_LOCATION,
     STATE_DRIVING,
 )
-from .coordinator import (
-    CirclesMembersDataUpdateCoordinator,
-    MemberDataUpdateCoordinator,
-)
+from .coordinator import L360ConfigEntry, MemberDataUpdateCoordinator
 from .helpers import ConfigOptions, MemberData, MemberID, NoLocReason
 
 _LOGGER = logging.getLogger(__name__)
@@ -56,17 +51,12 @@ _LOGGER = logging.getLogger(__name__)
 
 async def async_setup_entry(
     hass: HomeAssistant,
-    entry: ConfigEntry,
+    entry: L360ConfigEntry,
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up the device tracker platform."""
-    coordinator = cast(
-        CirclesMembersDataUpdateCoordinator, hass.data[DOMAIN]["coordinator"]
-    )
-    mem_coordinator = cast(
-        dict[MemberID, MemberDataUpdateCoordinator],
-        hass.data[DOMAIN]["mem_coordinator"],
-    )
+    coordinator = entry.runtime_data.coordinator
+    mem_coordinator = entry.runtime_data.mem_coordinator
     entities: dict[MemberID, Life360DeviceTracker] = {}
 
     async def async_process_data() -> None:
@@ -122,7 +112,7 @@ class Life360DeviceTracker(
     _attr_attribution = ATTRIBUTION
     _attr_translation_key = "tracker"
     _attr_unique_id: MemberID
-    coordinator: MemberDataUpdateCoordinator
+    # coordinator: MemberDataUpdateCoordinator
     _warned_loc_unknown = False
 
     _unrecorded_attributes = frozenset(
@@ -412,7 +402,7 @@ class Life360DeviceTracker(
         self._prev_data = self._data
 
     async def _async_config_entry_updated(
-        self, _: HomeAssistant, entry: ConfigEntry
+        self, _: HomeAssistant, entry: L360ConfigEntry
     ) -> None:
         """Run when the config entry has been updated."""
         if self._options == (new_options := ConfigOptions.from_dict(entry.options)):

--- a/custom_components/life360/device_tracker.py
+++ b/custom_components/life360/device_tracker.py
@@ -6,7 +6,7 @@ import asyncio
 from collections.abc import Mapping
 from contextlib import suppress
 from copy import deepcopy
-from functools import cached_property
+from functools import cached_property  # pylint: disable=hass-deprecated-import
 import logging
 from typing import Any, cast
 

--- a/custom_components/life360/device_tracker.py
+++ b/custom_components/life360/device_tracker.py
@@ -15,6 +15,7 @@ from homeassistant.components.device_tracker.config_entry import TrackerEntity
 from homeassistant.const import (
     ATTR_BATTERY_CHARGING,
     ATTR_GPS_ACCURACY,
+    ENTITY_MATCH_ALL,
     STATE_NOT_HOME,
     STATE_UNKNOWN,
     UnitOfSpeed,
@@ -95,7 +96,7 @@ async def async_setup_entry(
             *(
                 entity.update_location()
                 for entity in entities.values()
-                if entity_id == "all" or entity.entity_id in entity_id
+                if entity_id == ENTITY_MATCH_ALL or entity.entity_id in entity_id
             )
         )
 

--- a/custom_components/life360/device_tracker.py
+++ b/custom_components/life360/device_tracker.py
@@ -101,8 +101,8 @@ async def async_setup_entry(
         )
 
     await async_process_data()
-    async_dispatcher_connect(hass, SIGNAL_MEMBERS_CHANGED, async_process_data)
-    async_dispatcher_connect(hass, SIGNAL_UPDATE_LOCATION, update_location)
+    entry.async_on_unload(async_dispatcher_connect(hass, SIGNAL_MEMBERS_CHANGED, async_process_data))
+    entry.async_on_unload(async_dispatcher_connect(hass, SIGNAL_UPDATE_LOCATION, update_location))
 
 
 class Life360DeviceTracker(

--- a/custom_components/life360/device_tracker.py
+++ b/custom_components/life360/device_tracker.py
@@ -101,8 +101,12 @@ async def async_setup_entry(
         )
 
     await async_process_data()
-    entry.async_on_unload(async_dispatcher_connect(hass, SIGNAL_MEMBERS_CHANGED, async_process_data))
-    entry.async_on_unload(async_dispatcher_connect(hass, SIGNAL_UPDATE_LOCATION, update_location))
+    entry.async_on_unload(
+        async_dispatcher_connect(hass, SIGNAL_MEMBERS_CHANGED, async_process_data)
+    )
+    entry.async_on_unload(
+        async_dispatcher_connect(hass, SIGNAL_UPDATE_LOCATION, update_location)
+    )
 
 
 class Life360DeviceTracker(

--- a/custom_components/life360/manifest.json
+++ b/custom_components/life360/manifest.json
@@ -3,11 +3,11 @@
   "name": "Life360",
   "codeowners": ["@pnbruckner"],
   "config_flow": true,
-  "documentation": "https://github.com/pnbruckner/ha-life360/blob/0.5.4/README.md",
+  "documentation": "https://github.com/pnbruckner/ha-life360/blob/0.6.0b0/README.md",
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/pnbruckner/ha-life360/issues",
   "loggers": ["life360"],
   "requirements": ["life360==7.0.1"],
   "single_config_entry": true,
-  "version": "0.5.4"
+  "version": "0.6.0b0"
 }

--- a/custom_components/life360/translations/en.json
+++ b/custom_components/life360/translations/en.json
@@ -1,8 +1,7 @@
 {
     "config": {
         "abort": {
-            "reauth_successful": "Re-authentication was successful",
-            "single_instance_allowed": "Life360 supports only one configuration. Adding additional ones is not needed."
+            "reauth_successful": "Re-authentication was successful"
         },
         "create_entry": {
             "default": "Tracker entities cannot be created until list of Circles & Members is retrieved from server. Due to server restrictions, this could take ten minutes or more. Monitor progress via WARNING messages in system log."

--- a/custom_components/life360/translations/en.json
+++ b/custom_components/life360/translations/en.json
@@ -17,8 +17,9 @@
         "step": {
             "init": {
                 "title": "Basic Options",
+                "description": "The GPS accuracy attribute defines the radius of a circle around the GPS point wherein the device is located. Hence, bigger numbers mean LESS accuracy. A limit to the accuracy radius may be set below, or it may be left blank. If set, any updates that are less accurate than this value will be ignored. If used, a good starting point is 100m.",
                 "data": {
-                    "max_gps_accuracy": "Max GPS accuracy",
+                    "max_gps_accuracy": "GPS accuracy radius limit",
                     "driving_speed": "Driving speed threshold",
                     "driving": "Show driving as state",
                     "verbosity": "DEBUG message verbosity"
@@ -101,8 +102,9 @@
         "step": {
             "init": {
                 "title": "Basic Options",
+                "description": "The GPS accuracy attribute defines the radius of a circle around the GPS point wherein the device is located. Hence, bigger numbers mean LESS accuracy. A limit to the accuracy radius may be set below, or it may be left blank. If set, any updates that are less accurate than this value will be ignored. If used, a good starting point is 100m.",
                 "data": {
-                    "max_gps_accuracy": "Max GPS accuracy",
+                    "max_gps_accuracy": "GPS accuracy radius limit",
                     "driving_speed": "Driving speed threshold",
                     "driving": "Show driving as state",
                     "verbosity": "DEBUG message verbosity"

--- a/hacs.json
+++ b/hacs.json
@@ -1,4 +1,4 @@
 {
     "name": "Life360",
-    "homeassistant": "2023.8.0"
+    "homeassistant": "2024.8.3"
 }

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,4 +1,4 @@
 -r requirements.txt
 
-# HA 2024.11.0
-pytest-homeassistant-custom-component==0.13.181
+# HA 2025.3.3
+pytest-homeassistant-custom-component==0.13.224

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,4 +1,4 @@
 -r requirements.txt
 
-# HA 2025.3.3
-pytest-homeassistant-custom-component==0.13.224
+# HA 2025.9.1
+pytest-homeassistant-custom-component==0.13.278

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -27,7 +27,7 @@ def auto_enable_custom_integrations(enable_custom_integrations):
 
 
 @pytest.fixture(autouse=True)
-def MockStoreWorkAround() -> Generator[None, None, None]:
+def MockStoreWorkAround() -> Generator[None]:
     """Work around broken hass_storage in old pytest_homeassistant_custom_component."""
     # Versions before 0.13.54 did not use default encoder, so sets did not get converted
     # to lists, causing a JSON serialization error that was not caught. Work around the
@@ -49,7 +49,7 @@ def MockStoreWorkAround() -> Generator[None, None, None]:
 
 
 @pytest.fixture
-def dt_now() -> Generator[DtNowMock, None, None]:
+def dt_now() -> Generator[DtNowMock]:
     """Mock util.dt.now."""
     real = dt_util.now
     with patch("homeassistant.util.dt.now", autospec=True) as mock:
@@ -75,7 +75,7 @@ Life360API_Data = Mapping[str | None, Mapping[str, Life360API_SideEffect]]
 #
 # Any name/method not present in data will use default.
 @pytest.fixture(autouse=True)
-def MockLife360(request: pytest.FixtureRequest) -> Generator[MagicMock, None, None]:
+def MockLife360(request: pytest.FixtureRequest) -> Generator[MagicMock]:
     """Mock Life360."""
 
     if param := getattr(request, "param", None):

--- a/tests/test_migration.py
+++ b/tests/test_migration.py
@@ -26,7 +26,7 @@ MIGRATION_MESSAGE = "Migrating Life360 integration entries from version 1 to " +
 
 
 @pytest.fixture
-def setup_entry_mock(hass: HomeAssistant) -> Generator[AsyncMock, None, None]:
+def setup_entry_mock(hass: HomeAssistant) -> Generator[AsyncMock]:
     """Mock async_setup_entry."""
     with patch("custom_components.life360.async_setup_entry", autospec=True) as mock:
         # Teardown, in newer HA versions, will unload config entries. Add DOMAIN to
@@ -37,7 +37,7 @@ def setup_entry_mock(hass: HomeAssistant) -> Generator[AsyncMock, None, None]:
 
 
 @pytest.fixture(scope="module")
-def unload_entry_mock() -> Generator[AsyncMock, None, None]:
+def unload_entry_mock() -> Generator[AsyncMock]:
     """Mock async_unload_entry."""
     with patch("custom_components.life360.async_unload_entry", autospec=True) as mock:
         mock.return_value = True


### PR DESCRIPTION
- Drop support for HA versions before 2024.8.3.
- Add better descriptions for max_gps_accuracy config option.
- Fix bugs related to integration unloading/reloading.