### PR TITLE
[codex] Fix Life360 403 recovery and startup hangs

### DIFF
--- a/custom_components/life360/__init__.py
+++ b/custom_components/life360/__init__.py
@@ -104,11 +104,20 @@ async def async_setup_entry(hass: HomeAssistant, entry: L360ConfigEntry) -> bool
             mem_crd = MemberDataUpdateCoordinator(hass, coordinator, mid)
             config_entries.current_entry.set(entry_was)
             mem_coordinator[mid] = mem_crd
-            coros.append(mem_crd.async_refresh())
+            # Do not block entry setup or member discovery on an initial refresh.
+            # These requests can sit in long retry loops when Life360 is returning
+            # transient 403s, which causes Home Assistant to cancel setup entirely.
+            entry.async_create_background_task(
+                hass,
+                mem_crd.async_refresh(),
+                f"Refresh Member {mid}",
+            )
         if coros:
             await asyncio.gather(*coros)
             if forward:
                 async_dispatcher_send(hass, SIGNAL_MEMBERS_CHANGED)
+        elif forward:
+            async_dispatcher_send(hass, SIGNAL_MEMBERS_CHANGED)
 
     @callback
     def process_data() -> None:

--- a/custom_components/life360/api.py
+++ b/custom_components/life360/api.py
@@ -1,0 +1,295 @@
+"""Life360 API wrapper with a curl-backed fallback."""
+
+from __future__ import annotations
+
+import asyncio
+from contextlib import suppress
+from json import JSONDecodeError
+import json
+import logging
+from shutil import which
+from typing import Any, cast
+from urllib.parse import urlencode
+
+from life360 import CommError, Life360Error, LoginError, NotFound, NotModified
+from life360 import RateLimited, Unauthorized
+from life360.api import (
+    _EXC_REPR_REDACTIONS,
+    _HEADERS,
+    _RESP_REPR_REDACTIONS,
+    _RESP_TEXT_ALL_REDACTIONS,
+    _RESP_TEXT_BASIC_REDACTIONS,
+    _URL_REDACTIONS,
+    Life360 as BaseLife360,
+    _format_exc,
+)
+from life360.const import HTTP_Error
+
+_LOGGER = logging.getLogger(__name__)
+_CURL_STATUS_MARKER = "__L360_HTTP_STATUS__:"
+_CURL_BINARIES = (which("curl"), "/usr/bin/curl", "/usr/local/bin/curl", "/bin/curl")
+
+_CURL_RETRY_STATUS_CODES = frozenset(
+    {
+        HTTP_Error.BAD_GATEWAY,
+        HTTP_Error.SERVICE_UNAVAILABLE,
+        HTTP_Error.GATEWAY_TIME_OUT,
+        HTTP_Error.SERVER_UNKNOWN_ERROR,
+    }
+)
+
+
+class Life360(BaseLife360):
+    """Upstream Life360 client with a curl_cffi fallback for Cloudflare 403s."""
+
+    def __init__(
+        self,
+        session,
+        max_retries: int,
+        authorization: str | None = None,
+        *,
+        name: str | None = None,
+        verbosity: int = 0,
+    ) -> None:
+        """Initialize API."""
+        super().__init__(
+            session,
+            max_retries,
+            authorization,
+            name=name,
+            verbosity=verbosity,
+        )
+        self._curl_timeout = getattr(getattr(session, "timeout", None), "total", None)
+        self._curl_bin = next((path for path in _CURL_BINARIES if path), None)
+        self._prefer_curl = False
+        self._warned_missing_curl = False
+
+    def clear_cookies(self) -> None:
+        """Clear cookies kept by both transports."""
+        self._session.cookie_jar.clear()
+
+    async def async_close(self) -> None:
+        """Close resources used by the fallback session."""
+        return None
+
+    async def _request(
+        self,
+        url: str,
+        /,
+        raise_not_modified: bool,
+        method: str = "get",
+        *,
+        authorization: str | None = None,
+        **kwargs: dict[str, Any],
+    ) -> Any:
+        """Make a request to server."""
+        if self._prefer_curl:
+            return await self._curl_request(
+                url,
+                raise_not_modified,
+                method,
+                authorization=authorization,
+                **kwargs,
+            )
+
+        try:
+            return await super()._request(
+                url,
+                raise_not_modified,
+                method,
+                authorization=authorization,
+                **kwargs,
+            )
+        except LoginError as exc:
+            try:
+                result = await self._curl_request(
+                    url,
+                    raise_not_modified,
+                    method,
+                    authorization=authorization,
+                    **kwargs,
+                )
+            except Life360Error as curl_exc:
+                self._logger.warning(
+                    "curl fallback failed for %s after aiohttp 403: %s",
+                    self._redact(url, _URL_REDACTIONS),
+                    type(curl_exc).__name__,
+                )
+                raise exc
+
+            self._prefer_curl = True
+            self._logger.warning(
+                "Switching to curl subprocess transport after aiohttp 403 for %s",
+                self._redact(url, _URL_REDACTIONS),
+            )
+            return result
+
+    async def _curl_request(
+        self,
+        url: str,
+        /,
+        raise_not_modified: bool,
+        method: str = "get",
+        *,
+        authorization: str | None = None,
+        **kwargs: dict[str, Any],
+    ) -> Any:
+        """Make a request to server using the curl CLI."""
+        if authorization is None:
+            authorization = self.authorization
+        if authorization is None:
+            raise LoginError("Must login")
+        if not self._curl_bin:
+            if not self._warned_missing_curl:
+                self._warned_missing_curl = True
+                self._logger.warning("curl fallback unavailable: curl executable not found")
+            raise CommError("curl executable not found", None)
+
+        headers: dict[str, str] = {}
+        if authorization != "":
+            headers["authorization"] = authorization
+        if raise_not_modified and (etag := self._etags.get(url)):
+            headers["if-none-match"] = etag
+        headers = _HEADERS | headers | kwargs.pop("headers", {})
+
+        body: bytes | None = None
+        if json_data := kwargs.pop("json", None):
+            headers.setdefault("content-type", "application/json")
+            body = json.dumps(json_data).encode()
+        elif data := kwargs.pop("data", None):
+            if isinstance(data, (bytes, bytearray)):
+                body = bytes(data)
+            elif isinstance(data, str):
+                body = data.encode()
+            else:
+                headers.setdefault("content-type", "application/x-www-form-urlencoded")
+                body = urlencode(data).encode()
+
+        if params := kwargs.pop("params", None):
+            encoded = urlencode(params, doseq=True)
+            url = f"{url}{'&' if '?' in url else '?'}{encoded}"
+
+        cmd = [
+            self._curl_bin,
+            "--silent",
+            "--show-error",
+            "--location",
+            "--compressed",
+            "--request",
+            method.upper(),
+            "--url",
+            url,
+            "--write-out",
+            f"\n{_CURL_STATUS_MARKER}%{{http_code}}",
+        ]
+        if self._curl_timeout is not None:
+            cmd.extend(["--max-time", str(self._curl_timeout)])
+        for key, value in headers.items():
+            cmd.extend(["--header", f"{key}: {value}"])
+        if body is not None:
+            cmd.extend(["--data-binary", "@-"])
+
+        for attempt in range(1, self._max_attempts + 1):
+            try:
+                proc = await asyncio.create_subprocess_exec(
+                    *cmd,
+                    stdin=asyncio.subprocess.PIPE if body is not None else None,
+                    stdout=asyncio.subprocess.PIPE,
+                    stderr=asyncio.subprocess.PIPE,
+                )
+                stdout, stderr = await proc.communicate(body)
+            except OSError as exc:
+                if attempt < self._max_attempts:
+                    continue
+                raise CommError(
+                    self._redact(_format_exc(exc), _URL_REDACTIONS), None
+                ) from exc
+
+            text, _, status_str = stdout.decode(errors="replace").rpartition(
+                f"\n{_CURL_STATUS_MARKER}"
+            )
+            status = int(status_str) if status_str.isdigit() else None
+
+            if proc.returncode != 0 and status is None:
+                self._logger.debug(
+                    "Curl fallback request error: %s(%s), attempt %i: %s",
+                    method.upper(),
+                    self._redact(url, _URL_REDACTIONS),
+                    attempt,
+                    self._redact(stderr.decode(errors="replace"), _EXC_REPR_REDACTIONS),
+                )
+                if attempt < self._max_attempts:
+                    continue
+                raise CommError(
+                    self._redact(stderr.decode(errors="replace"), _URL_REDACTIONS)
+                    or "curl request failed",
+                    None,
+                ) from None
+
+            self._dump_curl_resp(status, text)
+            if status == HTTP_Error.NOT_MODIFIED:
+                raise NotModified
+            if status in _CURL_RETRY_STATUS_CODES and attempt < self._max_attempts:
+                continue
+            if status is None:
+                raise CommError("curl request returned no HTTP status", None)
+            if status >= 400:
+                raise self._curl_error(status, text)
+
+            try:
+                return json.loads(text)
+            except JSONDecodeError as exc:
+                self._logger.debug(
+                    "While parsing curl fallback response: %r: %s",
+                    text,
+                    self._redact(repr(exc), _EXC_REPR_REDACTIONS),
+                )
+                raise Life360Error(
+                    self._redact(_format_exc(exc), _URL_REDACTIONS)
+                ) from None
+
+        raise Life360Error("Unexpected curl request flow")
+
+    def _curl_error(self, status: int, text: str) -> Life360Error:
+        """Convert a curl HTTP status and response body to the library's exceptions."""
+        headers: dict[str, str] = {}
+        err_msg = text
+        try:
+            err_msg = cast(dict[str, str], json.loads(text))["errorMessage"].lower()
+        except (KeyError, TypeError, ValueError, JSONDecodeError):
+            pass
+
+        match status:
+            case HTTP_Error.UNAUTHORIZED:
+                raise Unauthorized(err_msg, headers.get("www-authenticate"))
+            case HTTP_Error.FORBIDDEN:
+                raise LoginError(err_msg)
+            case HTTP_Error.NOT_FOUND:
+                raise NotFound(err_msg)
+            case HTTP_Error.TOO_MANY_REQUESTS:
+                retry_after = headers.get("retry-after")
+                try:
+                    retry_after_value = float(retry_after) if retry_after else None
+                except ValueError:
+                    retry_after_value = None
+                raise RateLimited(err_msg, retry_after_value)
+            case _:
+                raise CommError(err_msg, status)
+
+    def _dump_curl_resp(self, status: int | None, text: str) -> None:
+        """Dump curl fallback response to log."""
+        if self.verbosity >= 1:
+            self._logger.debug(
+                "Curl fallback response status: %s",
+                status,
+            )
+        if self.verbosity >= 2 and text:
+            self._logger.debug(
+                "Curl fallback response data: %s",
+                self._redact(
+                    text,
+                    _RESP_TEXT_ALL_REDACTIONS
+                    if self.verbosity < 3
+                    else _RESP_TEXT_BASIC_REDACTIONS,
+                ),
+            )

--- a/custom_components/life360/config_flow.py
+++ b/custom_components/life360/config_flow.py
@@ -432,6 +432,8 @@ class Life360Flow(ConfigEntryBaseFlow, ABC):
                     assert self._authorization is not None
                     authorization = self._authorization
             finally:
+                if close := getattr(locals().get("api"), "async_close", None):
+                    await close()
                 session.detach()
         elif self._authorization is not None:
             authorization = self._authorization

--- a/custom_components/life360/coordinator.py
+++ b/custom_components/life360/coordinator.py
@@ -493,7 +493,11 @@ class CirclesMembersDataUpdateCoordinator(DataUpdateCoordinator[CirclesMembersDa
                     return RequestError.NOT_MODIFIED
 
                 except LoginError as exc:
-                    self._acct_data[aid].session.cookie_jar.clear()
+                    api = self._acct_data[aid].api
+                    if clear_cookies := getattr(api, "clear_cookies", None):
+                        clear_cookies()
+                    else:
+                        self._acct_data[aid].session.cookie_jar.clear()
 
                     if lrle_resp is LoginRateLimitErrResp.RETRY or (
                         lrle_resp is LoginRateLimitErrResp.LTD_LOGIN_ERROR_RETRY
@@ -690,6 +694,12 @@ class CirclesMembersDataUpdateCoordinator(DataUpdateCoordinator[CirclesMembersDa
         for aid in aids:
             acct = self._acct_data.pop(aid)
             acct.session.detach()
+            if close := getattr(acct.api, "async_close", None):
+                self.config_entry.async_create_task(
+                    self.hass,
+                    close(),
+                    f"Close curl session for {aid}",
+                )
             acct.failed_task.cancel()
 
 

--- a/custom_components/life360/helpers.py
+++ b/custom_components/life360/helpers.py
@@ -8,7 +8,7 @@ from datetime import datetime
 from enum import IntEnum
 from typing import Any, NewType, Self, cast
 
-from life360 import Life360
+from .api import Life360
 
 from homeassistant.const import CONF_ENABLED, CONF_PASSWORD, UnitOfLength
 from homeassistant.core import HomeAssistant

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,117 @@
+"""Tests for the Life360 API wrapper."""
+
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from custom_components.life360.api import Life360
+from life360 import LoginError
+import pytest
+
+
+def make_session() -> MagicMock:
+    """Create a mocked aiohttp session."""
+    session = MagicMock()
+    session.timeout = SimpleNamespace(total=60)
+    session.cookie_jar = MagicMock()
+    return session
+
+
+@pytest.mark.asyncio
+async def test_request_switches_to_curl_after_login_error() -> None:
+    """Test that a 403 switches future requests to curl_cffi."""
+    api = Life360(make_session(), 0, authorization="Bearer token")
+    api._curl_request = AsyncMock(side_effect=[{"value": 1}, {"value": 2}])
+
+    with patch(
+        "life360.api.Life360._request",
+        new=AsyncMock(side_effect=LoginError("forbidden")),
+    ) as mock_request:
+        assert await api._request("https://example.com/one", False) == {"value": 1}
+        assert await api._request("https://example.com/two", False) == {"value": 2}
+
+    assert mock_request.await_count == 1
+    assert api._curl_request.await_count == 2
+    await api.async_close()
+
+
+@pytest.mark.asyncio
+async def test_request_keeps_login_error_if_curl_fallback_fails() -> None:
+    """Test that the original login error is preserved if curl also gets a 403."""
+    api = Life360(make_session(), 0, authorization="Bearer token")
+    api._curl_request = AsyncMock(side_effect=LoginError("still forbidden"))
+
+    with patch(
+        "life360.api.Life360._request",
+        new=AsyncMock(side_effect=LoginError("forbidden")),
+    ):
+        with pytest.raises(LoginError, match="forbidden"):
+            await api._request("https://example.com/one", False)
+
+    assert api._prefer_curl is False
+    await api.async_close()
+
+
+@pytest.mark.asyncio
+async def test_clear_cookies_clears_both_transports() -> None:
+    """Test cookie clearing for the aiohttp transport."""
+    session = make_session()
+    api = Life360(session, 0, authorization="Bearer token")
+    api.clear_cookies()
+
+    session.cookie_jar.clear.assert_called_once_with()
+    await api.async_close()
+
+
+class FakeProcess:
+    """Test double for asyncio subprocesses."""
+
+    def __init__(
+        self, stdout: bytes, stderr: bytes = b"", returncode: int = 0
+    ) -> None:
+        """Initialize the fake process."""
+        self._stdout = stdout
+        self._stderr = stderr
+        self.returncode = returncode
+
+    async def communicate(self, _input: bytes | None = None) -> tuple[bytes, bytes]:
+        """Return captured process output."""
+        return self._stdout, self._stderr
+
+
+@pytest.mark.asyncio
+async def test_curl_request_returns_json() -> None:
+    """Test curl subprocess success path."""
+    api = Life360(make_session(), 0, authorization="Bearer token")
+    api._curl_bin = "/usr/bin/curl"
+    response = b'{"circles":[{"id":"1"}]}\n__L360_HTTP_STATUS__:200'
+
+    with patch(
+        "custom_components.life360.api.asyncio.create_subprocess_exec",
+        new=AsyncMock(return_value=FakeProcess(response)),
+    ) as mock_exec:
+        assert await api._curl_request("https://example.com/circles", False) == {
+            "circles": [{"id": "1"}]
+        }
+
+    assert mock_exec.await_count == 1
+    await api.async_close()
+
+
+@pytest.mark.asyncio
+async def test_curl_request_maps_403_to_login_error() -> None:
+    """Test curl subprocess maps HTTP 403 to LoginError."""
+    api = Life360(make_session(), 0, authorization="Bearer token")
+    api._curl_bin = "/usr/bin/curl"
+    response = b"forbidden\n__L360_HTTP_STATUS__:403"
+
+    with patch(
+        "custom_components.life360.api.asyncio.create_subprocess_exec",
+        new=AsyncMock(return_value=FakeProcess(response)),
+    ):
+        with pytest.raises(LoginError, match="forbidden"):
+            await api._curl_request("https://example.com/circles", False)
+
+    await api.async_close()

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -17,6 +17,7 @@ from custom_components.life360.const import (
     MAX_LTD_LOGIN_ERROR_RETRIES,
     UPDATE_INTERVAL,
 )
+from custom_components.life360.coordinator import MemberDataUpdateCoordinator
 from custom_components.life360.helpers import AccountID, ConfigOptions, MemberID
 from life360 import LoginError
 import pytest
@@ -524,6 +525,79 @@ async def test_reload_new_member(hass: HomeAssistant, hass_storage: MutableStora
     # Now there are two Members.
     cast(list[str], circles[cir1["id"]]["mids"]).append(cast(str, mem2["id"]))
     assert_stored_data(hass_storage, circles, [mem1, mem2])
+
+
+@pytest.mark.parametrize(
+    "MockLife360",
+    [
+        {
+            "aid1": {
+                "get_circles": [LoginError("TEST: Forbidden"), [cir1]],
+                "get_circle_members": repeat([mem1]),
+            },
+        },
+    ],
+    indirect=["MockLife360"],
+)
+async def test_setup_does_not_wait_for_member_refresh(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    hass_storage: MutableStorage,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """Test entry setup is not blocked by a stalled member refresh."""
+    mem1_info = MemberInfo.from_data(mem1)
+    hass_storage[DOMAIN] = {
+        "version": 1,
+        "data": {
+            "circles": {
+                cir1["id"]: {
+                    "name": cir1["name"],
+                    "aids": ["aid1"],
+                    "mids": [mem1_info.mid],
+                }
+            },
+            "mem_details": {
+                mem1_info.mid: {
+                    "name": mem1_info.name,
+                    "entity_picture": mem1_info.entity_picture,
+                }
+            },
+        },
+    }
+
+    started = asyncio.Event()
+    release = asyncio.Event()
+
+    async def block_refresh(_: MemberDataUpdateCoordinator) -> None:
+        started.set()
+        await release.wait()
+
+    monkeypatch.setattr(MemberDataUpdateCoordinator, "async_refresh", block_refresh)
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        version=Life360ConfigFlow.VERSION,
+        options=cfg_options(1, verbosity=3),
+    )
+    entry.add_to_hass(hass)
+
+    with assert_setup_component(0, DOMAIN):
+        setup_task = asyncio.create_task(async_setup_component(hass, DOMAIN, {}))
+        try:
+            await asyncio.wait_for(started.wait(), timeout=1)
+            assert await asyncio.wait_for(asyncio.shield(setup_task), timeout=1)
+        finally:
+            release.set()
+            await hass.async_block_till_done()
+
+    entity_id = entity_registry.async_get_entity_id(
+        DT_DOMAIN, DOMAIN, MemberID(cast(str, mem1["id"]))
+    )
+    assert entity_id
+    state = hass.states.get(entity_id)
+    assert state
+    assert state.state == STATE_UNKNOWN
 
 
 LOGIN_ERROR_MESSAGE = "TEST: Login error"


### PR DESCRIPTION
Fixes #79.

## What changed

This PR addresses two separate failure modes seen in the recent Life360 breakage reports.

1. Initial member refreshes no longer block config entry setup.
   When Life360 starts returning repeated auth failures, those startup refreshes can sit in long retry loops long enough for Home Assistant to cancel entry setup entirely.

2. The integration now falls back to the real `curl` CLI after aiohttp gets Cloudflare 403 responses.
   In live testing, the upstream aiohttp client continued to get blocked by Cloudflare while the same requests succeeded through `curl`. The new wrapper preserves the existing library behavior first, then switches to a subprocess `curl` transport after the first 403 so circles and member fetches can continue.

## Why

Users in issue #79 were seeing two different symptoms:

- `403 Forbidden` responses from the Life360 API for circle and member requests
- `CancelledError` and incomplete setup when those failures happened during startup

The startup cancellation was a real integration bug in this repo.
The 403 behavior appears to be tied to the HTTP client fingerprint rather than the token itself, so this patch works around it by switching transports after the blocked aiohttp request path is detected.

## Impact

- Home Assistant entry setup is no longer held hostage by a stalled initial member refresh.
- Circle and member retrieval can recover on systems where aiohttp is blocked but `curl` succeeds.
- Existing cookie-clearing and cleanup paths still work with the new wrapper.

## Validation

- `./.venv/bin/pytest -q`
- `./.venv/bin/python -m compileall custom_components tests`
- Live Home Assistant validation on 2026-03-27:
  - confirmed repeated aiohttp `403 Forbidden` failures for `/v4/circles`
  - confirmed the patched integration logged `Switching to curl subprocess transport after aiohttp 403`
  - confirmed the config entry completed boot without a fresh `Could not retrieve full Circles & Members list from server` warning after the fallback switched over
