### PR TITLE
Work around 2026.2 breaking change

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -72,11 +72,14 @@ jobs:
         # 0.13.272 -> HA 2025.8.3
         # 0.13.281 -> HA 2025.9.4
         # 0.13.289 -> HA 2025.10.4
+        # --- 3.13, 3.14
         # 0.13.297 -> HA 2025.11.3
         # 0.13.301 -> HA 2025.12.4 # Missing 2025.12.5
+        # --- 3.13.11, 3.14.2
         # 0.13.308 -> HA 2026.1.3
         # 0.13.316 -> HA 2026.2.3
-        # 0.13.318 -> HA 2026.3.2
+        # --- 3.14.2
+        # 0.13.320 -> HA 2026.3.4
         include:
           - hass-test-cc-version: "0.13.252"
             python-version: "3.13"
@@ -84,7 +87,11 @@ jobs:
             python-version: "3.13"
           - hass-test-cc-version: "0.13.297"
             python-version: "3.14"
-          - hass-test-cc-version: "0.13.318"
+          - hass-test-cc-version: "0.13.316"
+            python-version: "3.13.11"
+          - hass-test-cc-version: "0.13.316"
+            python-version: "3.14.2"
+          - hass-test-cc-version: "0.13.320"
             python-version: "3.14.2"
     steps:
       - name: 📥 Checkout the repository

--- a/custom_components/life360/__init__.py
+++ b/custom_components/life360/__init__.py
@@ -91,7 +91,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: L360ConfigEntry) -> bool
     await coordinator.async_config_entry_first_refresh()
     mem_coordinator: dict[MemberID, MemberDataUpdateCoordinator] = {}
 
-    async def async_process_data(forward: bool = False) -> None:
+    async def async_process_data(forward: bool) -> None:
         """Process Members."""
         mids = set(coordinator.data.mem_details)
         coros = [
@@ -111,12 +111,12 @@ async def async_setup_entry(hass: HomeAssistant, entry: L360ConfigEntry) -> bool
                 async_dispatcher_send(hass, SIGNAL_MEMBERS_CHANGED)
 
     @callback
-    def process_data() -> None:
+    def process_data(forward: bool = True) -> None:
         """Process Members."""
         create_process_task = partial(
             entry.async_create_background_task,
             hass,
-            async_process_data(forward=True),
+            async_process_data(forward),
             "Process Members",
         )
         # eager_start parameter was added in 2024.3.
@@ -125,7 +125,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: L360ConfigEntry) -> bool
         except TypeError:
             create_process_task()
 
-    await async_process_data()
+    process_data(forward=False)
     entry.async_on_unload(coordinator.async_add_listener(process_data))
     entry.runtime_data = L360Coordinators(coordinator, mem_coordinator)
 

--- a/custom_components/life360/__init__.py
+++ b/custom_components/life360/__init__.py
@@ -90,8 +90,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: L360ConfigEntry) -> bool
     coordinator = CirclesMembersDataUpdateCoordinator(hass, store)
     await coordinator.async_config_entry_first_refresh()
     mem_coordinator: dict[MemberID, MemberDataUpdateCoordinator] = {}
+    entry.runtime_data = L360Coordinators(coordinator, mem_coordinator)
 
-    async def async_process_data(forward: bool) -> None:
+    async def async_process_data() -> None:
         """Process Members."""
         mids = set(coordinator.data.mem_details)
         coros = [
@@ -107,16 +108,15 @@ async def async_setup_entry(hass: HomeAssistant, entry: L360ConfigEntry) -> bool
             coros.append(mem_crd.async_refresh())
         if coros:
             await asyncio.gather(*coros)
-            if forward:
-                async_dispatcher_send(hass, SIGNAL_MEMBERS_CHANGED)
+            async_dispatcher_send(hass, SIGNAL_MEMBERS_CHANGED)
 
     @callback
-    def process_data(forward: bool = True) -> None:
+    def process_data() -> None:
         """Process Members."""
         create_process_task = partial(
             entry.async_create_background_task,
             hass,
-            async_process_data(forward),
+            async_process_data(),
             "Process Members",
         )
         # eager_start parameter was added in 2024.3.
@@ -125,12 +125,11 @@ async def async_setup_entry(hass: HomeAssistant, entry: L360ConfigEntry) -> bool
         except TypeError:
             create_process_task()
 
-    process_data(forward=False)
-    entry.async_on_unload(coordinator.async_add_listener(process_data))
-    entry.runtime_data = L360Coordinators(coordinator, mem_coordinator)
-
     # Set up components for our platforms.
     await hass.config_entries.async_forward_entry_setups(entry, _PLATFORMS)
+
+    process_data()
+    entry.async_on_unload(coordinator.async_add_listener(process_data))
     return True
 
 

--- a/custom_components/life360/config_flow.py
+++ b/custom_components/life360/config_flow.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from functools import cached_property  # pylint: disable=hass-deprecated-import
-import logging
 from typing import Any, cast
 
 from life360 import CommError, Life360Error, LoginError
@@ -25,7 +24,6 @@ from homeassistant.const import (
     UnitOfSpeed,
 )
 from homeassistant.core import callback
-from homeassistant.helpers.aiohttp_client import async_create_clientsession
 from homeassistant.helpers.issue_registry import async_delete_issue
 from homeassistant.helpers.selector import (
     BooleanSelector,
@@ -44,7 +42,6 @@ from homeassistant.util.unit_system import METRIC_SYSTEM
 from . import helpers
 from .const import (
     COMM_MAX_RETRIES,
-    COMM_TIMEOUT,
     CONF_ACCOUNTS,
     CONF_AUTHORIZATION,
     CONF_DRIVING_SPEED,
@@ -54,9 +51,7 @@ from .const import (
     CONF_VERBOSITY,
     DOMAIN,
 )
-from .helpers import Account, AccountID, ConfigOptions
-
-_LOGGER = logging.getLogger(__name__)
+from .helpers import Account, AccountID, ConfigOptions, get_session
 
 LIMIT_GPS_ACC = "limit_gps_acc"
 SET_DRIVE_SPEED = "set_drive_speed"
@@ -414,7 +409,7 @@ class Life360Flow(ConfigEntryBaseFlow, ABC):
 
         # Check that credentials work by getting new authorization & testing it.
         if self._enabled:
-            session = async_create_clientsession(self.hass, timeout=COMM_TIMEOUT)
+            session = get_session(self.hass)
             try:
                 name = self._username if self._opts.verbosity >= 3 else None
                 api = helpers.Life360(

--- a/custom_components/life360/coordinator.py
+++ b/custom_components/life360/coordinator.py
@@ -18,7 +18,6 @@ from life360 import Life360Error, LoginError, NotFound, NotModified, RateLimited
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers.aiohttp_client import async_create_clientsession
 from homeassistant.helpers.dispatcher import async_dispatcher_send
 from homeassistant.helpers.issue_registry import IssueSeverity, async_create_issue
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
@@ -27,7 +26,6 @@ from homeassistant.util import dt as dt_util
 from . import helpers
 from .const import (
     COMM_MAX_RETRIES,
-    COMM_TIMEOUT,
     DOMAIN,
     LOGIN_ERROR_RETRY_DELAY,
     LTD_LOGIN_ERROR_RETRY_DELAY,
@@ -46,6 +44,7 @@ from .helpers import (
     MemberDetails,
     MemberID,
     NoLocReason,
+    get_session,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -668,7 +667,7 @@ class CirclesMembersDataUpdateCoordinator(DataUpdateCoordinator[CirclesMembersDa
             acct = self._options.accounts[aid]
             if not acct.enabled:
                 continue
-            session = async_create_clientsession(self.hass, timeout=COMM_TIMEOUT)
+            session = get_session(self.hass)
             name = aid if self._options.verbosity >= 3 else f"Account {idx + 1}"
             api = helpers.Life360(
                 session,

--- a/custom_components/life360/device_tracker.py
+++ b/custom_components/life360/device_tracker.py
@@ -100,7 +100,6 @@ async def async_setup_entry(
             )
         )
 
-    await async_process_data()
     entry.async_on_unload(
         async_dispatcher_connect(hass, SIGNAL_MEMBERS_CHANGED, async_process_data)
     )

--- a/custom_components/life360/helpers.py
+++ b/custom_components/life360/helpers.py
@@ -6,18 +6,35 @@ from collections.abc import Mapping
 from dataclasses import asdict, dataclass, field
 from datetime import datetime
 from enum import IntEnum
+import logging
 from typing import Any, NewType, Self, cast
 
+from aiohttp import ClientSession
 from life360 import Life360
 
-from homeassistant.const import CONF_ENABLED, CONF_PASSWORD, UnitOfLength
-from homeassistant.core import HomeAssistant
+from homeassistant.const import (
+    CONF_ENABLED,
+    CONF_PASSWORD,
+    EVENT_HOMEASSISTANT_CLOSE,
+    MAJOR_VERSION,
+    MINOR_VERSION,
+    UnitOfLength,
+)
+from homeassistant.core import Event, HomeAssistant
+from homeassistant.helpers.aiohttp_client import (
+    MAXIMUM_CONNECTIONS,
+    MAXIMUM_CONNECTIONS_PER_HOST,
+    HomeAssistantTCPConnector,
+    _async_get_or_create_resolver,
+    async_create_clientsession,
+)
 from homeassistant.helpers.restore_state import ExtraStoredData
 from homeassistant.helpers.storage import Store
-from homeassistant.util import dt as dt_util
+from homeassistant.util import dt as dt_util, ssl as ssl_util
 from homeassistant.util.unit_conversion import DistanceConverter
 
 from .const import (
+    COMM_TIMEOUT,
     CONF_ACCOUNTS,
     CONF_AUTHORIZATION,
     CONF_DRIVING_SPEED,
@@ -29,6 +46,8 @@ from .const import (
     SPEED_FACTOR_MPH,
 )
 
+_LOGGER = logging.getLogger(__name__)
+
 # So testing can patch in one place.
 LIFE360 = Life360
 
@@ -36,6 +55,35 @@ LIFE360 = Life360
 AccountID = NewType("AccountID", str)
 CircleID = NewType("CircleID", str)
 MemberID = NewType("MemberID", str)
+
+
+def get_session(hass: HomeAssistant) -> ClientSession:
+    """Get a new ClientSession."""
+    session = async_create_clientsession(hass, timeout=COMM_TIMEOUT)
+    if (MAJOR_VERSION, MINOR_VERSION) < (2026, 2):
+        return session
+
+    # Starting in 2026.2, the SSLContext object seems to upset the Life360
+    # server, or more likely, Cloudflare. Create a new connector with the
+    # older style SSLContext object, and use that instead with the
+    # ClientSession.
+    _LOGGER.debug("Creating new TCPConnector with older SSLContext")
+    ssl_context = ssl_util.client_context()
+    connector = HomeAssistantTCPConnector(
+        ssl=ssl_context,
+        limit=MAXIMUM_CONNECTIONS,
+        limit_per_host=MAXIMUM_CONNECTIONS_PER_HOST,
+        resolver=_async_get_or_create_resolver(hass),
+    )
+    session._connector = connector
+
+    async def close_connector(event: Event) -> None:
+        """Close connector pool."""
+        await connector.close()
+
+    hass.bus.async_listen_once(EVENT_HOMEASSISTANT_CLOSE, close_connector)
+
+    return session
 
 
 @dataclass

--- a/custom_components/life360/manifest.json
+++ b/custom_components/life360/manifest.json
@@ -3,11 +3,11 @@
   "name": "Life360",
   "codeowners": ["@pnbruckner"],
   "config_flow": true,
-  "documentation": "https://github.com/pnbruckner/ha-life360/blob/0.7.1b0/README.md",
+  "documentation": "https://github.com/pnbruckner/ha-life360/blob/0.7.1b1/README.md",
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/pnbruckner/ha-life360/issues",
   "loggers": ["life360"],
   "requirements": ["life360==7.0.1"],
   "single_config_entry": true,
-  "version": "0.7.1b0"
+  "version": "0.7.1b1"
 }

--- a/custom_components/life360/manifest.json
+++ b/custom_components/life360/manifest.json
@@ -3,11 +3,11 @@
   "name": "Life360",
   "codeowners": ["@pnbruckner"],
   "config_flow": true,
-  "documentation": "https://github.com/pnbruckner/ha-life360/blob/0.7.0/README.md",
+  "documentation": "https://github.com/pnbruckner/ha-life360/blob/0.7.1b0/README.md",
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/pnbruckner/ha-life360/issues",
   "loggers": ["life360"],
   "requirements": ["life360==7.0.1"],
   "single_config_entry": true,
-  "version": "0.7.0"
+  "version": "0.7.1b0"
 }

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,4 +1,4 @@
 -r requirements.txt
 
 # HA 2026.3.2
-pytest-homeassistant-custom-component==0.13.318
+pytest-homeassistant-custom-component==0.13.320

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -164,6 +164,7 @@ async def test_no_circles_members(
     with assert_setup_component(0, DOMAIN):
         assert await async_setup_component(hass, DOMAIN, {})
         await hass.async_block_till_done()
+        await asyncio.sleep(0.1)
 
     # Check WARNING messages.
     expected = 1 if store_data is None else 0
@@ -300,6 +301,7 @@ async def test_circles_members_no_loc(
     with assert_setup_component(0, DOMAIN):
         assert await async_setup_component(hass, DOMAIN, {})
         await hass.async_block_till_done()
+        await asyncio.sleep(0.1)
 
     # Check that a device_tracker entity has been created for each Member.
     for mem_info in [MemberInfo.from_data(member) for member in members]:
@@ -387,6 +389,7 @@ async def test_circles_members_delayed(
     with assert_setup_component(0, DOMAIN):
         assert await async_setup_component(hass, DOMAIN, {})
         await hass.async_block_till_done()
+        await asyncio.sleep(0.1)
 
     # First retrieval of Circles failed, but second attempt succeeded.
     # There should now be two Members.
@@ -442,6 +445,7 @@ async def test_acct_added(
     with assert_setup_component(0, DOMAIN):
         assert await async_setup_component(hass, DOMAIN, {})
         await hass.async_block_till_done()
+        await asyncio.sleep(0.1)
 
     aid1 = AccountID("aid1")
     mid1 = MemberID(cast(str, mem1["id"]))
@@ -511,6 +515,7 @@ async def test_reload_new_member(hass: HomeAssistant, hass_storage: MutableStora
     with assert_setup_component(0, DOMAIN):
         assert await async_setup_component(hass, DOMAIN, {})
         await hass.async_block_till_done()
+        await asyncio.sleep(0.1)
 
     # Initially there is only one Member.
     circles = {
@@ -520,6 +525,7 @@ async def test_reload_new_member(hass: HomeAssistant, hass_storage: MutableStora
 
     assert await hass.config_entries.async_reload(entry.entry_id)
     await hass.async_block_till_done()
+    await asyncio.sleep(0.1)
 
     # Now there are two Members.
     cast(list[str], circles[cir1["id"]]["mids"]).append(cast(str, mem2["id"]))
@@ -598,6 +604,7 @@ async def test_login_error(
     with assert_setup_component(0, DOMAIN):
         assert await async_setup_component(hass, DOMAIN, {})
         await hass.async_block_till_done()
+        await asyncio.sleep(0.1)
 
     aid = AccountID("aid1")
     mid = MemberID(cast(str, mem1["id"]))
@@ -696,6 +703,7 @@ async def test_remove_entry(
     with assert_setup_component(0, DOMAIN):
         assert await async_setup_component(hass, DOMAIN, {})
         await hass.async_block_till_done()
+        await asyncio.sleep(0.1)
 
     # Check that account binary online sensor exists and is on.
     bs_entity_id = entity_registry.async_get_entity_id(BS_DOMAIN, DOMAIN, "aid1")
@@ -711,6 +719,7 @@ async def test_remove_entry(
     # Remove config entry.
     assert await hass.config_entries.async_remove(entry.entry_id)
     await hass.async_block_till_done()
+    await asyncio.sleep(0.1)
 
     # Check that binary online sensor is gone.
     state = hass.states.get(bs_entity_id)


### PR DESCRIPTION
- Starting with 2026.2 the aiohttp.ClientSession created changed enough to upset the Life360 server, or more likely, Cloudflare. Work around this by creating a ClientSession more like what was created before. Specifically, make the SSLContext object used by the TCPConnector object more like it was before.
- Do initial member updates in a background task so that errors don't slow down system startup.

Note that this fix is a bit fragile since it depends on theoretically private HA functions and class members. But, then again, this integration has been "fragile" since Day 1 because it depends on an undocumented & unsupported Life360 API.

See #79 