### PR TITLE
Use a private SSLContext in get_session() to avoid shared-context ALPN corruption

### DIFF
--- a/custom_components/life360/helpers.py
+++ b/custom_components/life360/helpers.py
@@ -7,6 +7,7 @@ from dataclasses import asdict, dataclass, field
 from datetime import datetime
 from enum import IntEnum
 import logging
+import ssl
 from typing import Any, NewType, Self, cast
 
 from aiohttp import ClientSession
@@ -30,7 +31,7 @@ from homeassistant.helpers.aiohttp_client import (
 )
 from homeassistant.helpers.restore_state import ExtraStoredData
 from homeassistant.helpers.storage import Store
-from homeassistant.util import dt as dt_util, ssl as ssl_util
+from homeassistant.util import dt as dt_util
 from homeassistant.util.unit_conversion import DistanceConverter
 
 from .const import (
@@ -51,6 +52,15 @@ _LOGGER = logging.getLogger(__name__)
 # So testing can patch in one place.
 LIFE360 = Life360
 
+# Cloudflare rejects a ClientHello whose only ALPN entry is "http/1.1", which is
+# what aiohttp's default context advertises. ssl_util.client_context() avoids that,
+# but returns a process-wide cached object that httpx/httpcore mutates in place via
+# set_alpn_protocols() -- so whether our requests carry ALPN depends on what other
+# integrations happen to have run first, and the resulting 403s look intermittent.
+# Own the context rather than sharing it. Built at import, which runs in Home
+# Assistant's import executor, because loading CA certs is blocking I/O.
+_SSL_CONTEXT = ssl.create_default_context()
+
 
 AccountID = NewType("AccountID", str)
 CircleID = NewType("CircleID", str)
@@ -64,13 +74,11 @@ def get_session(hass: HomeAssistant) -> ClientSession:
         return session
 
     # Starting in 2026.2, the SSLContext object seems to upset the Life360
-    # server, or more likely, Cloudflare. Create a new connector with the
-    # older style SSLContext object, and use that instead with the
-    # ClientSession.
-    _LOGGER.debug("Creating new TCPConnector with older SSLContext")
-    ssl_context = ssl_util.client_context()
+    # server, or more likely, Cloudflare. Create a new connector with our own
+    # SSLContext object, and use that instead with the ClientSession.
+    _LOGGER.debug("Creating new TCPConnector with private SSLContext")
     connector = HomeAssistantTCPConnector(
-        ssl=ssl_context,
+        ssl=_SSL_CONTEXT,
         limit=MAXIMUM_CONNECTIONS,
         limit_per_host=MAXIMUM_CONNECTIONS_PER_HOST,
         resolver=_async_get_or_create_resolver(hass),


### PR DESCRIPTION
Fixes the intermittent Cloudflare `403 Forbidden` on `GET /v4/circles` that several people report in #93.

Short version: the `client_context()` workaround added in 0.10.x is correct in isolation, but the context it returns is a process-wide shared object that another library can mutate out from under us. When that happens the request goes out with an ALPN extension we never asked for, and Cloudflare blocks it.

## Root cause

Cloudflare rejects a TLS ClientHello whose **only** ALPN entry is `http/1.1`. Browsers offer `h2,http/1.1`, or nothing at all. Offering `http/1.1` alone is an automation signature.

aiohttp's default context does exactly that:

```python
# aiohttp/connector.py, _make_ssl_context(verified=True)
sslcontext = ssl.create_default_context()
sslcontext.set_alpn_protocols(("http/1.1",))
```

`get_session()` already avoids this by calling `ssl_util.client_context()`, which defaults to `SSL_ALPN_NONE`. The problem is that the contexts in `homeassistant/util/ssl.py` are `@cache` decorated and pre-warmed at module load, so there are only three of them per process and **every caller gets the same object back**.

Home Assistant documents the hazard in `homeassistant/helpers/httpx_client.py`:

```python
# Use the requested ALPN protocols directly to ensure proper SSL context
# bucketing. httpx/httpcore mutates SSL contexts by calling set_alpn_protocols(),
# so we pre-set the correct protocols to prevent shared context corruption.
```

HA's own httpx helper protects itself by always passing explicit ALPN so it lands in a dedicated bucket. Anything else that calls `client_context()` with no arguments and hands the result to httpx mutates the shared no-ALPN context in place, and this integration inherits the result.

That accounts for the symptoms in #93 that made it so hard to pin down:

- the 403s are intermittent, because they depend on whether some other integration has used httpx yet
- `Creating new TCPConnector with older SSLContext` logs happily and changes nothing
- it cannot be reproduced on a clean instance, because it depends on which other integrations are installed

## Reproduction

Single process, single context object, on an affected instance:

```
client_context() is cached/shared: True
1. before any httpx use                 200  application/json
   -> httpx has now touched the SAME context object
2. after httpx used same context        403  text/html
```

## The fix

Own the context instead of sharing it:

```python
_SSL_CONTEXT = ssl.create_default_context()
```

Built at module import rather than inside `get_session()`, because `create_default_context()` loads CA certificates from disk and `homeassistant/block_async_io.py` patches `load_default_certs`, `load_verify_locations`, `load_cert_chain` and `set_default_verify_paths` to fail in the event loop. Custom integrations are imported in HA's `ImportExecutor` thread, so this stays off the loop. Confirmed zero `Detected blocking call` warnings after deploying.

This keeps `get_session()` synchronous, so no call sites change.

## Verification

Run inside the HA core container, Python 3.14.6, OpenSSL 3.5.7, aiohttp 3.14.3, HA 2026.8.2 (HAOS 18.2):

| Variant | Result |
| --- | --- |
| aiohttp built-in default context | 403 `text/html`, `server: cloudflare` (3/3 runs) |
| `ssl.create_default_context()` | 200 `application/json` (3/3) |
| `ssl_util.client_context()` in a clean process | 200 (3/3) |
| `ssl_util.client_context()` after httpx touched it | 403 |
| this patch, deployed | 200, and `_SSL_CONTEXT is client_context()` is `False` |

Controlled comparison on the live instance, 15 seconds apart, same container and same source IP: the running integration got 403 at 12:28:59 while a direct request using a private context got 200 at 12:29:14.

After deploying this patch and restarting, all three `device_tracker` entities populated with live location, battery and zone data, and there have been no further 403s.

## Things I ruled out along the way

In case they come up again in #93:

- **HTTP version and ALPN presence as such.** `curl --http1.1` and `curl --no-alpn` both return 200, but so does plain `curl`, which offers `h2,http/1.1`. The discriminator is specifically advertising `http/1.1` on its own, not ALPN being present.
- **Broader JA3/JA4 fingerprinting.** Plain aiohttp reaches the API fine once the context is private, so impersonating a browser TLS stack (for example with `curl_cffi`) is not needed today.
- **Extra request headers.** On this instance something injects `sentry-trace` and `baggage` headers into outbound requests. Requests carrying them return 200, so they are not the trigger.
- **Address family.** IPv6 is not routable from the core container here, and IPv4 returns 200.
- **The `session._connector` assignment.** It does take effect; a session built that way and one built with the connector passed at construction both behave identically.
- **Timeouts.** `COMM_TIMEOUT` is honoured correctly on the swapped connector.

Note also that #93 mixes at least three distinct failures: this 403, HTTP 401, and HTTP 429 with very large `retry_after` values. This PR only addresses the 403.

One unrelated observation while reading `coordinator._request()`: on the `LoginRateLimitErrResp.RETRY` branch, `LoginError` retries every `LOGIN_ERROR_RETRY_DELAY` with no attempt cap, unlike the `LTD_LOGIN_ERROR_RETRY` branch which stops at `MAX_LTD_LOGIN_ERROR_RETRIES`. With debug logging off that loop is silent, which is part of why this looked like a hang rather than a repeating 403. Happy to open that separately if it is worth changing.
