### PR TITLE
Fix retained Life360 request tasks

### DIFF
--- a/custom_components/life360/coordinator.py
+++ b/custom_components/life360/coordinator.py
@@ -61,7 +61,6 @@ class AccountData:
     session: ClientSession
     api: helpers.Life360
     failed: asyncio.Event
-    failed_task: asyncio.Task
     online: bool = True
 
 
@@ -444,8 +443,14 @@ class CirclesMembersDataUpdateCoordinator(DataUpdateCoordinator[CirclesMembersDa
         delay_reason = ""
         warned = False
 
-        failed_task = self._acct_data[aid].failed_task
+        failed = self._acct_data[aid].failed
         request_task: asyncio.Task[_R] | None = None
+
+        async def cancel_request_if_failed(request: asyncio.Task[_R]) -> None:
+            """Cancel the request if another request disables the account."""
+            await failed.wait()
+            request.cancel()
+
         try:
             while True:
                 if delay is not None:
@@ -468,20 +473,21 @@ class CirclesMembersDataUpdateCoordinator(DataUpdateCoordinator[CirclesMembersDa
                         delay,
                     )
                     await asyncio.sleep(delay)
-                request_task = self.config_entry.async_create_background_task(
+                current_request = self.config_entry.async_create_background_task(
                     self.hass,
                     target(*args),
                     f"Make request to {aid}",
                 )
-                done, _ = await asyncio.wait(
-                    [failed_task, request_task], return_when=asyncio.FIRST_COMPLETED
+                request_task = current_request
+
+                # Do not race against a shared task with asyncio.wait here. The pending
+                # task's awaited-by graph would retain every completed _request task.
+                # See https://github.com/python/cpython/issues/152569.
+                failed_watcher = self.config_entry.async_create_background_task(
+                    self.hass,
+                    cancel_request_if_failed(current_request),
+                    f"Monitor failed request to {aid}",
                 )
-                if failed_task in done:
-                    (rt := request_task).cancel()
-                    request_task = None
-                    with suppress(asyncio.CancelledError, Life360Error):
-                        await rt
-                    return RequestError.NO_DATA
 
                 try:
                     # if aid == "federicktest95@gmail.com":
@@ -493,6 +499,15 @@ class CirclesMembersDataUpdateCoordinator(DataUpdateCoordinator[CirclesMembersDa
                     #             await rt
                     #         raise LoginError("TEST TEST TEST")
                     result = await request_task
+
+                except asyncio.CancelledError:
+                    current_task = asyncio.current_task()
+                    if current_task and current_task.cancelling():
+                        raise
+                    if failed.is_set():
+                        request_task = None
+                        return RequestError.NO_DATA
+                    raise
 
                 except NotFound:
                     self._set_acct_exc(aid)
@@ -540,8 +555,18 @@ class CirclesMembersDataUpdateCoordinator(DataUpdateCoordinator[CirclesMembersDa
 
                 else:
                     request_task = None
+                    current_task = asyncio.current_task()
+                    if current_task and current_task.cancelling():
+                        raise asyncio.CancelledError
+                    if failed.is_set():
+                        return RequestError.NO_DATA
                     self._set_acct_exc(aid)
                     return result
+
+                finally:
+                    failed_watcher.cancel()
+                    with suppress(asyncio.CancelledError):
+                        await failed_watcher
 
         except asyncio.CancelledError:
             if request_task:
@@ -693,19 +718,13 @@ class CirclesMembersDataUpdateCoordinator(DataUpdateCoordinator[CirclesMembersDa
                 verbosity=self._options.verbosity,
             )
             failed = asyncio.Event()
-            failed_task = self.config_entry.async_create_background_task(
-                self.hass,
-                failed.wait(),
-                f"Monitor failed requests to {aid}",
-            )
-            self._acct_data[aid] = AccountData(session, api, failed, failed_task)
+            self._acct_data[aid] = AccountData(session, api, failed)
 
     def _delete_acct_data(self, aids: Iterable[AccountID]) -> None:
         """Delete data previously created for each specified Life360 account."""
         for aid in aids:
             acct = self._acct_data.pop(aid)
             acct.session.detach()
-            acct.failed_task.cancel()
 
 
 class MemberDataUpdateCoordinator(DataUpdateCoordinator[MemberData]):

--- a/tests/test_task_retention.py
+++ b/tests/test_task_retention.py
@@ -1,0 +1,196 @@
+"""Regression test for completed Life360 request task retention."""
+
+from __future__ import annotations
+
+import asyncio
+import gc
+import weakref
+
+import pytest
+from homeassistant.core import HomeAssistant
+from homeassistant.setup import async_setup_component
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components.life360.config_flow import Life360ConfigFlow
+from custom_components.life360.const import DOMAIN
+from custom_components.life360.coordinator import RequestError
+
+from .test_init import cfg_options
+
+
+async def test_completed_client_request_tasks_are_released(
+    hass: HomeAssistant,
+) -> None:
+    """Completed client request tasks should not remain reachable."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        version=Life360ConfigFlow.VERSION,
+        options=cfg_options(1, verbosity=3),
+    )
+    entry.add_to_hass(hass)
+    assert await async_setup_component(hass, DOMAIN, {})
+    await hass.async_block_till_done()
+    await asyncio.sleep(0.1)
+
+    coordinator = entry.runtime_data.coordinator
+    task_refs: dict[str, list[weakref.ReferenceType[asyncio.Task]]] = {
+        "Make client request to aid1": [],
+        "Make request to aid1": [],
+        "Monitor failed request to aid1": [],
+    }
+    create_background_task = entry.async_create_background_task
+
+    def capture_background_task(*args, **kwargs):
+        task = create_background_task(*args, **kwargs)
+        if task.get_name() in task_refs:
+            task_refs[task.get_name()].append(weakref.ref(task))
+        return task
+
+    entry.async_create_background_task = capture_background_task
+
+    async def request() -> dict[str, str]:
+        return {"payload": "x" * 10_000}
+
+    for _ in range(100):
+        assert await coordinator._client_request(  # noqa: SLF001
+            "aid1", request, msg="regression test"
+        ) == {"payload": "x" * 10_000}
+
+    await asyncio.sleep(0)
+    gc.collect()
+
+    assert {name: len(refs) for name, refs in task_refs.items()} == {
+        "Make client request to aid1": 100,
+        "Make request to aid1": 100,
+        "Monitor failed request to aid1": 100,
+    }
+    assert all(ref() is None for refs in task_refs.values() for ref in refs)
+
+
+async def test_failed_account_cancels_in_flight_request(
+    hass: HomeAssistant,
+) -> None:
+    """An account failure should stop its in-flight client requests."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        version=Life360ConfigFlow.VERSION,
+        options=cfg_options(1, verbosity=3),
+    )
+    entry.add_to_hass(hass)
+    assert await async_setup_component(hass, DOMAIN, {})
+    await hass.async_block_till_done()
+
+    coordinator = entry.runtime_data.coordinator
+    started = asyncio.Event()
+
+    async def request() -> None:
+        started.set()
+        await asyncio.Event().wait()
+
+    task = asyncio.create_task(
+        coordinator._client_request("aid1", request, msg="failure test")  # noqa: SLF001
+    )
+    await started.wait()
+    coordinator._acct_data["aid1"].failed.set()  # noqa: SLF001
+
+    assert await asyncio.wait_for(task, timeout=1) is RequestError.NO_DATA
+
+
+async def test_external_cancellation_wins_account_failure(
+    hass: HomeAssistant,
+) -> None:
+    """External cancellation should propagate when an account also fails."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        version=Life360ConfigFlow.VERSION,
+        options=cfg_options(1, verbosity=3),
+    )
+    entry.add_to_hass(hass)
+    assert await async_setup_component(hass, DOMAIN, {})
+    await hass.async_block_till_done()
+
+    coordinator = entry.runtime_data.coordinator
+    started = asyncio.Event()
+
+    async def request() -> None:
+        started.set()
+        await asyncio.Event().wait()
+
+    task = asyncio.create_task(
+        coordinator._request("aid1", request, msg="cancellation race")  # noqa: SLF001
+    )
+    await started.wait()
+    task.cancel()
+    coordinator._acct_data["aid1"].failed.set()  # noqa: SLF001
+
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+
+async def test_account_failure_wins_cancellation_resistant_request(
+    hass: HomeAssistant,
+) -> None:
+    """Account failure should win even if a request suppresses cancellation."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        version=Life360ConfigFlow.VERSION,
+        options=cfg_options(1, verbosity=3),
+    )
+    entry.add_to_hass(hass)
+    assert await async_setup_component(hass, DOMAIN, {})
+    await hass.async_block_till_done()
+
+    coordinator = entry.runtime_data.coordinator
+    started = asyncio.Event()
+
+    async def request() -> str:
+        started.set()
+        try:
+            await asyncio.Event().wait()
+            return "unexpected request completion"
+        except asyncio.CancelledError:
+            return "request ignored cancellation"
+
+    task = asyncio.create_task(
+        coordinator._request("aid1", request, msg="failure race")  # noqa: SLF001
+    )
+    await started.wait()
+    coordinator._acct_data["aid1"].failed.set()  # noqa: SLF001
+
+    assert await asyncio.wait_for(task, timeout=1) is RequestError.NO_DATA
+
+
+async def test_external_cancellation_wins_resistant_request(
+    hass: HomeAssistant,
+) -> None:
+    """External cancellation should win even if the request suppresses it."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        version=Life360ConfigFlow.VERSION,
+        options=cfg_options(1, verbosity=3),
+    )
+    entry.add_to_hass(hass)
+    assert await async_setup_component(hass, DOMAIN, {})
+    await hass.async_block_till_done()
+
+    coordinator = entry.runtime_data.coordinator
+    started = asyncio.Event()
+
+    async def request() -> str:
+        started.set()
+        try:
+            await asyncio.Event().wait()
+            return "unexpected request completion"
+        except asyncio.CancelledError:
+            return "request ignored cancellation"
+
+    task = asyncio.create_task(
+        coordinator._request(  # noqa: SLF001
+            "aid1", request, msg="resistant cancellation"
+        )
+    )
+    await started.wait()
+    task.cancel()
+
+    with pytest.raises(asyncio.CancelledError):
+        await task


### PR DESCRIPTION
Fixes #101.

## What changed

Python 3.14 has an upstream `asyncio.wait(..., FIRST_COMPLETED)` retention bug when many requests repeatedly wait against the same long-lived task: https://github.com/python/cpython/issues/152569

Life360 triggered that behavior by racing every client request against one account-lifetime failure task. This change keeps the shared failure event but replaces the shared task with a bounded watcher for each active request. The watcher is canceled and awaited when its request finishes.

The cancellation behavior is preserved when:

- another request disables the account;
- account failure and external cancellation happen together;
- the underlying request catches `CancelledError` and returns normally.

## Tests

- Added a regression test proving completed outer request tasks, inner request tasks, and failure watchers are released.
- Added tests for account-failure cancellation and external-cancellation races.
- Verified the retention test fails with the original implementation and passes with this change.
- Full suite on Python 3.14.5: `18 passed, 2 xfailed`.
- Full suite on Python 3.13.11: `18 passed, 2 xfailed`.

I also tested the patch on Home Assistant Core 2026.8.3 with Life360 0.10.2. The original code retained 924 completed Life360 `_request()` tasks after about 5.5 minutes. With this patch, the same profiler check after six minutes found zero retained Life360 request tasks; all 10 entities remained available and memory stayed between 971.7 and 976.8 MiB with no swap use.
